### PR TITLE
Ensure Kafka messages are replayed from the source

### DIFF
--- a/src/main/java/tlc2/overrides/source/KafkaSource.java
+++ b/src/main/java/tlc2/overrides/source/KafkaSource.java
@@ -55,6 +55,8 @@ public class KafkaSource implements Source {
         config.setProperty("bootstrap.servers", String.format("%s:%d", host, port));
         config.setProperty("client.id", InetAddress.getLocalHost().getHostName());
         config.setProperty("group.id", InetAddress.getLocalHost().getHostName());
+        config.setProperty("enable.auto.commit", "false");
+        config.setProperty("auto.offset.reset", "earliest");
         config.setProperty("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
         config.setProperty("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
         config.setProperty("client.dns.lookup", "use_all_dns_ips");


### PR DESCRIPTION
The default Kafka consumer configuration blocks and waits for new traces. This change replays and checks all traces in the topic.